### PR TITLE
Allow array for playlist PropTypes

### DIFF
--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -34,7 +34,10 @@ const propTypes = {
   onVideoLoad: PropTypes.func,
   playerId: PropTypes.string.isRequired,
   playerScript: PropTypes.string.isRequired,
-  playlist: PropTypes.string,
+  playlist: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
 };
 
 export default propTypes;

--- a/test/get-player-opts.test.js
+++ b/test/get-player-opts.test.js
@@ -155,3 +155,19 @@ test('getPlayerOpts() with customProps', (t) => {
 
   t.end();
 });
+
+test('getPlayerOpts() with playlist as an array', (t) => {
+  const mockFile = 'mock file';
+
+  const mockPlaylist = [{
+    file: mockFile,
+  }];
+
+  const actual = getPlayerOpts({
+    playlist: mockPlaylist,
+  });
+
+  t.deepEqual(actual.playlist, mockPlaylist, 'it sets the playlist property');
+
+  t.end();
+});

--- a/test/react-jw-player.browser-test.js
+++ b/test/react-jw-player.browser-test.js
@@ -42,6 +42,10 @@ test('<ReactJWPlayer> when no jwplayer script is present', (t) => {
 test('<ReactJWPlayer> when jwplayer script is present', (t) => {
   const testPlayerId = 'playerOne';
   const testPlayerIdTwo = 'playerTwo';
+  const testPlayerIdThree = 'playerThree';
+  const testArrayPlaylist = [{
+    file: 'file',
+  }];
   const initializeCalls = [];
 
   function stubbedInitialize() {
@@ -66,14 +70,21 @@ test('<ReactJWPlayer> when jwplayer script is present', (t) => {
     />,
   );
 
+  mount(
+    <ReactJWPlayer
+      playerId={testPlayerIdThree}
+      playerScript='script'
+      playlist={testArrayPlaylist}
+    />,
+  );
 
   const script = document.querySelector('#jw-player-script');
   t.equal(typeof script.onload, 'function', 'it sets script.onload to a function');
 
   script.onload();
   t.deepEqual(
-    initializeCalls, [testPlayerId, testPlayerIdTwo],
-    'script onload calls initialize on both mounted component',
+    initializeCalls, [testPlayerId, testPlayerIdTwo, testPlayerIdThree],
+    'script onload calls initialize on all mounted component',
   );
 
   t.end();


### PR DESCRIPTION
Allow to pass an array to the `playlist` prop. 

Fixes #30